### PR TITLE
Add get directions link to SpotDetailsPage

### DIFF
--- a/front-end/src/pages/SpotDetailsPage.js
+++ b/front-end/src/pages/SpotDetailsPage.js
@@ -48,6 +48,11 @@ export default function SpotDetailsPage() {
     setSelectedStar(0);
     setReviewText('');
   }
+  function handleOpenMaps() {
+  const query = `${spot.name} ${spot.address}`;
+  const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+  window.open(mapsUrl, '_blank', 'noopener,noreferrer');
+}
 
   /* ── Render ── */
   return (
@@ -84,9 +89,16 @@ export default function SpotDetailsPage() {
 
         {/* Location + hours preview */}
         <div className={styles.metaRow}>
-          <span className={styles.metaItem}><PinIcon /> {spot.address}</span>
-          <span className={styles.metaItem}><ClockIcon /> {spot.hours[0].time}</span>
-        </div>
+  <span className={styles.metaItem}><PinIcon /> {spot.address}</span>
+  <span className={styles.metaItem}><ClockIcon /> {spot.hours[0].time}</span>
+</div>
+
+
+<div className={styles.directionsRow}>
+  <button className={styles.directionsBtn} onClick={handleOpenMaps}>
+    <PinIcon /> Get Directions
+  </button>
+</div>
 
         {/* Rating row */}
         <div className={styles.ratingRow}>

--- a/front-end/src/pages/SpotDetailsPage.module.css
+++ b/front-end/src/pages/SpotDetailsPage.module.css
@@ -107,7 +107,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-3);
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-2);
 }
 
 .metaItem {
@@ -118,6 +118,26 @@
   color: var(--color-text-secondary);
 }
 
+.directionsRow {
+  margin-bottom: var(--space-5);
+}
+
+.directionsBtn {
+  background: none;
+  border: none;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-family: var(--font-body);
+  color: var(--color-accent);
+  cursor: pointer;
+}
+
+.directionsBtn:hover {
+  text-decoration: underline;
+}
 /* ── Rating row ── */
 .ratingRow {
   display: flex;
@@ -126,7 +146,7 @@
   padding: var(--space-4) 0;
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-2);
 }
 
 .stars {
@@ -171,7 +191,7 @@
 
 /* ── Busyness bar ── */
 .busynessSection {
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-2);
 }
 
 .busynessHeader {
@@ -220,7 +240,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-2);
 }
 
 .chip {
@@ -237,7 +257,7 @@
 
 /* ── Description ── */
 .descSection {
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-2);
 }
 
 .desc {
@@ -292,7 +312,14 @@
   font-family: var(--font-display);
   font-size: 20px;
   font-weight: 400;
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-2);
+}
+
+.savedMessage {
+  font-size: 15px;
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-2);
+  text-align: center;
 }
 
 /* Busyness overlay — level selector */
@@ -300,7 +327,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: var(--space-2);
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-2);
 }
 
 .levelBtn {


### PR DESCRIPTION
Implemented a Get Directions link on SpotDetailsPage.

Changes made:

added a Get Directions action below the location info
opens the current study spot in Google Maps using the spot name and address
added styling for the directions link to match the existing UI