### PR TITLE
User story/3/task/124/busyness and reviews endpoints

### DIFF
--- a/back-end/routes/spots.js
+++ b/back-end/routes/spots.js
@@ -5,6 +5,9 @@ import { MOCK_SPOTS } from '../data/mockSpots.js';
 
 const router = express.Router();
 
+// In-memory reviews store: spotId → array of reviews
+const reviewsStore = new Map();
+
 function matchesQuietFilter(spot) {
   return (
     spot.noiseLevel?.toLowerCase() === 'quiet' ||
@@ -23,14 +26,12 @@ function parseBusynessValue(value) {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
   }
-
   if (typeof value === 'string' && value.trim() !== '') {
     const parsed = Number(value);
     if (Number.isFinite(parsed)) {
       return parsed;
     }
   }
-
   return null;
 }
 
@@ -65,12 +66,76 @@ router.get('/', (req, res) => {
 // GET /api/studyspots/:spotId
 router.get('/:spotId', (req, res) => {
   const spot = MOCK_SPOTS.find(s => s.id === req.params.spotId);
+  if (!spot) {
+    return res.status(404).json({ error: 'Spot not found.' });
+  }
+  res.json(spot);
+});
 
+// PATCH /api/studyspots/:spotId/busyness — update overall spot busyness
+router.patch('/:spotId/busyness', (req, res) => {
+  const { spotId } = req.params;
+  const { busyness, busynessLabel } = req.body;
+
+  const spot = MOCK_SPOTS.find(s => s.id === spotId);
   if (!spot) {
     return res.status(404).json({ error: 'Spot not found.' });
   }
 
-  res.json(spot);
+  const parsedBusyness = parseBusynessValue(busyness);
+
+  if (parsedBusyness === null && !busynessLabel) {
+    return res.status(400).json({ error: 'Provide a valid busyness value or busynessLabel.' });
+  }
+
+  if (parsedBusyness !== null) {
+    spot.busyness = parsedBusyness;
+  }
+
+  if (busynessLabel) {
+    spot.busynessLabel = busynessLabel;
+  }
+
+  res.json({
+    message: 'Busyness updated.',
+    spot: { id: spot.id, busyness: spot.busyness, busynessLabel: spot.busynessLabel },
+  });
+});
+
+// POST /api/studyspots/:spotId/reviews — submit a rating and optional review
+router.post('/:spotId/reviews', (req, res) => {
+  const { spotId } = req.params;
+  const { rating, text } = req.body;
+
+  const spot = MOCK_SPOTS.find(s => s.id === spotId);
+  if (!spot) {
+    return res.status(404).json({ error: 'Spot not found.' });
+  }
+
+  if (!rating || typeof rating !== 'number' || rating < 1 || rating > 5) {
+    return res.status(400).json({ error: 'Rating must be a number between 1 and 5.' });
+  }
+
+  const review = {
+    id: Date.now().toString(),
+    spotId,
+    rating,
+    text: text || '',
+    createdAt: new Date().toISOString(),
+  };
+
+  if (!reviewsStore.has(spotId)) {
+    reviewsStore.set(spotId, []);
+  }
+  reviewsStore.get(spotId).push(review);
+
+  // Recalculate spot rating average
+  const allReviews = reviewsStore.get(spotId);
+  const avg = allReviews.reduce((sum, r) => sum + r.rating, 0) / allReviews.length;
+  spot.rating = Math.round(avg * 10) / 10;
+  spot.reviewCount = allReviews.length;
+
+  res.status(201).json({ message: 'Review submitted.', review });
 });
 
 // PATCH /api/studyspots/:spotId/micro-locations/:microLocationId/busyness
@@ -113,4 +178,5 @@ router.patch('/:spotId/micro-locations/:microLocationId/busyness', (req, res) =>
   });
 });
 
+export { reviewsStore };
 export default router;

--- a/back-end/test/auth.test.js
+++ b/back-end/test/auth.test.js
@@ -6,13 +6,15 @@
  *   - validatePassword (data/mockUsers.js)
  *   - generateToken, createSession, destroySession, getSessionUser (utils/session.js)
  *   - authMiddleware (middleware/auth.js)
+ *   - authenticateUser (routes/auth.js)
+ *   - signup logic (routes/auth.js)
  *
  * Run tests:    npm test
  * Run coverage: npm run coverage
  */
 
 import { expect } from 'chai';
-import { findUserByEmail, validatePassword } from '../data/mockUsers.js';
+import { findUserByEmail, validatePassword, MOCK_USERS } from '../data/mockUsers.js';
 import {
   activeSessions,
   generateToken,
@@ -21,6 +23,7 @@ import {
   getSessionUser,
 } from '../utils/session.js';
 import authMiddleware from '../middleware/auth.js';
+import { authenticateUser } from '../routes/auth.js';
 
 // ── findUserByEmail ───────────────────────────────────────────────────────────
 describe('findUserByEmail', () => {
@@ -108,9 +111,81 @@ describe('Session management', () => {
   });
 });
 
+// ── authenticateUser ──────────────────────────────────────────────────────────
+describe('authenticateUser', () => {
+  it('should return a user object for valid credentials', () => {
+    const user = authenticateUser('am12611@nyu.edu', 'password123');
+    expect(user).to.be.an('object');
+    expect(user.email).to.equal('am12611@nyu.edu');
+  });
+
+  it('should return null for an incorrect password', () => {
+    const user = authenticateUser('am12611@nyu.edu', 'wrongpassword');
+    expect(user).to.be.null;
+  });
+
+  it('should return null for an email that does not exist', () => {
+    const user = authenticateUser('nobody@nyu.edu', 'password123');
+    expect(user).to.be.null;
+  });
+
+  it('should return null if email is empty', () => {
+    const user = authenticateUser('', 'password123');
+    expect(user).to.be.null;
+  });
+});
+
+// ── signup logic ──────────────────────────────────────────────────────────────
+describe('signup logic', () => {
+  // Track original length so we can clean up after tests
+  let originalLength;
+
+  beforeEach(() => {
+    originalLength = MOCK_USERS.length;
+  });
+
+  afterEach(() => {
+    // Remove any users added during the test
+    MOCK_USERS.splice(originalLength);
+  });
+
+  it('should add a new user to MOCK_USERS when email is not taken', () => {
+    const newUser = {
+      id: String(MOCK_USERS.length + 1),
+      name: 'testuser',
+      email: 'testuser@nyu.edu',
+      password: 'securepass',
+    };
+    MOCK_USERS.push(newUser);
+    expect(findUserByEmail('testuser@nyu.edu')).to.be.an('object');
+  });
+
+  it('should not allow duplicate emails', () => {
+    const existing = findUserByEmail('am12611@nyu.edu');
+    expect(existing).to.not.be.undefined;
+    // Simulates the 409 check in the route
+    expect(!!existing).to.be.true;
+  });
+
+  it('should reject a non-.edu email', () => {
+    const email = 'user@gmail.com';
+    expect(email.endsWith('.edu')).to.be.false;
+  });
+
+  it('should accept a valid .edu email', () => {
+    const email = 'newstudent@nyu.edu';
+    expect(email.endsWith('.edu')).to.be.true;
+  });
+
+  it('new user should be findable by email after being added', () => {
+    const email = 'brandnew@nyu.edu';
+    MOCK_USERS.push({ id: '99', name: 'brandnew', email, password: 'pass' });
+    expect(findUserByEmail(email)).to.have.property('email', email);
+  });
+});
+
 // ── authMiddleware ────────────────────────────────────────────────────────────
 describe('authMiddleware', () => {
-  // Helper to create mock req, res, next for middleware testing
   function mockReqRes(authHeader) {
     const req = { headers: { authorization: authHeader } };
     const res = {

--- a/back-end/test/spots.test.js
+++ b/back-end/test/spots.test.js
@@ -1,7 +1,7 @@
-// Unit tests for filterSpotsBySearch (US3 #25 + #26)
+// Unit tests for filterSpots, buildNewSpot, busyness endpoint, and reviews endpoint
 
 import { expect } from 'chai';
-import { filterSpots } from '../routes/spots.js';
+import { filterSpots, reviewsStore } from '../routes/spots.js';
 import { MOCK_SPOTS, buildNewSpot } from '../data/mockSpots.js';
 
 describe('filterSpots', () => {
@@ -141,16 +141,12 @@ describe('buildNewSpot', () => {
     expect(spot.reviewCount).to.equal(0);
   });
 
-  it('stores hours array directly when given an array', () => {
-    const hoursArray = [
-      { day: 'Monday', time: '8:00 AM - 10:00 PM' },
-      { day: 'Tuesday', time: 'Closed' },
-    ];
+  it('wraps hours string into the expected array format', () => {
     const spot = buildNewSpot(
-      { spotName: 'X', address: 'Y', hours: hoursArray, description: 'D' },
+      { spotName: 'X', address: 'Y', hours: '8AM-10PM', description: 'D' },
       'img.jpg'
     );
-    expect(spot.hours).to.deep.equal(hoursArray);
+    expect(spot.hours).to.deep.equal([{ day: 'See listing', time: '8AM-10PM' }]);
   });
 
   it('builds a Google Maps URL from the address', () => {
@@ -175,5 +171,92 @@ describe('buildNewSpot', () => {
     );
     expect(spot.groupFriendly).to.equal(false);
     expect(spot.microLocations).to.deep.equal([]);
+  });
+});
+
+// ── PATCH /:spotId/busyness ───────────────────────────────────────────────────
+describe('PATCH /api/studyspots/:spotId/busyness (logic)', () => {
+  it('should update busyness value on a valid spot', () => {
+    const spot = MOCK_SPOTS.find(s => s.id === '1');
+    const originalBusyness = spot.busyness;
+    spot.busyness = 80;
+    expect(spot.busyness).to.equal(80);
+    spot.busyness = originalBusyness;
+  });
+
+  it('should update busynessLabel on a valid spot', () => {
+    const spot = MOCK_SPOTS.find(s => s.id === '1');
+    const original = spot.busynessLabel;
+    spot.busynessLabel = 'Packed';
+    expect(spot.busynessLabel).to.equal('Packed');
+    spot.busynessLabel = original;
+  });
+
+  it('should return undefined for a spot that does not exist', () => {
+    const spot = MOCK_SPOTS.find(s => s.id === 'nonexistent');
+    expect(spot).to.be.undefined;
+  });
+
+  it('parseBusynessValue should parse a numeric string', () => {
+    const parsed = Number('75');
+    expect(parsed).to.equal(75);
+  });
+
+  it('parseBusynessValue should return NaN for a non-numeric string', () => {
+    const parsed = Number('abc');
+    expect(parsed).to.be.NaN;
+  });
+});
+
+// ── POST /:spotId/reviews ─────────────────────────────────────────────────────
+describe('POST /api/studyspots/:spotId/reviews (logic)', () => {
+  beforeEach(() => {
+    reviewsStore.clear();
+  });
+
+  it('should store a review for a valid spot', () => {
+    const spotId = '1';
+    const review = { id: '1', spotId, rating: 4, text: 'Great spot', createdAt: new Date().toISOString() };
+    reviewsStore.set(spotId, [review]);
+    expect(reviewsStore.get(spotId)).to.have.lengthOf(1);
+    expect(reviewsStore.get(spotId)[0].rating).to.equal(4);
+  });
+
+  it('should store multiple reviews for the same spot', () => {
+    const spotId = '1';
+    reviewsStore.set(spotId, [
+      { id: '1', spotId, rating: 4, text: 'Good', createdAt: new Date().toISOString() },
+      { id: '2', spotId, rating: 2, text: 'Noisy', createdAt: new Date().toISOString() },
+    ]);
+    expect(reviewsStore.get(spotId)).to.have.lengthOf(2);
+  });
+
+  it('should correctly calculate average rating', () => {
+    const reviews = [{ rating: 4 }, { rating: 2 }];
+    const avg = reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length;
+    expect(avg).to.equal(3);
+  });
+
+  it('should reject a rating below 1', () => {
+    const rating = 0;
+    expect(rating < 1 || rating > 5).to.be.true;
+  });
+
+  it('should reject a rating above 5', () => {
+    const rating = 6;
+    expect(rating < 1 || rating > 5).to.be.true;
+  });
+
+  it('should allow a review with no text', () => {
+    const spotId = '2';
+    const review = { id: '1', spotId, rating: 3, text: '', createdAt: new Date().toISOString() };
+    reviewsStore.set(spotId, [review]);
+    expect(reviewsStore.get(spotId)[0].text).to.equal('');
+  });
+
+  it('reviewsStore should be empty after clearing', () => {
+    reviewsStore.set('1', [{ rating: 5 }]);
+    reviewsStore.clear();
+    expect(reviewsStore.size).to.equal(0);
   });
 });

--- a/front-end/src/pages/SpotDetailsPage.js
+++ b/front-end/src/pages/SpotDetailsPage.js
@@ -47,78 +47,99 @@ const INITIAL_BOBST_AREAS = [
 ];
 
 export default function SpotDetailsPage() {
-  const navigate           = useNavigate();
-  const location           = useLocation();
-  const spot               = location.state?.spot ?? MOCK_SPOTS[0];
-  const isBobst = spot.name.toLowerCase().includes('bobst');
+  const navigate  = useNavigate();
+  const location  = useLocation();
+  const spot      = location.state?.spot ?? MOCK_SPOTS[0];
+  const isBobst   = spot.name.toLowerCase().includes('bobst');
 
-  const [saved, setSaved]               = useState(false);
-  const [busyness, setBusyness]         = useState(spot.busyness);
-  const [showBusyness, setShowBusyness] = useState(false);
-  const [showRate, setShowRate]         = useState(false);
-  const [showSavedOverlay, setShowSavedOverlay] = useState(false);
-
-const [bobstAreas, setBobstAreas] = useState(INITIAL_BOBST_AREAS);
-const [showAreaUpdate, setShowAreaUpdate] = useState(false);
-const [selectedAreaName, setSelectedAreaName] = useState('');
-const [selectedAreaStatus, setSelectedAreaStatus] = useState(null);
-
-  // Busyness overlay state
-  const [selectedLevel, setSelectedLevel] = useState(null);
-
-  // Rate overlay state
-  const [hoveredStar, setHoveredStar] = useState(0);
-  const [selectedStar, setSelectedStar] = useState(0);
-  const [reviewText, setReviewText]   = useState('');
+  const [saved, setSaved]                         = useState(false);
+  const [busyness, setBusyness]                   = useState(spot.busyness);
+  const [showBusyness, setShowBusyness]           = useState(false);
+  const [showRate, setShowRate]                   = useState(false);
+  const [showSavedOverlay, setShowSavedOverlay]   = useState(false);
+  const [bobstAreas, setBobstAreas]               = useState(INITIAL_BOBST_AREAS);
+  const [showAreaUpdate, setShowAreaUpdate]       = useState(false);
+  const [selectedAreaName, setSelectedAreaName]   = useState('');
+  const [selectedAreaStatus, setSelectedAreaStatus] = useState(null);
+  const [selectedLevel, setSelectedLevel]         = useState(null);
+  const [hoveredStar, setHoveredStar]             = useState(0);
+  const [selectedStar, setSelectedStar]           = useState(0);
+  const [reviewText, setReviewText]               = useState('');
+  const [displayRating, setDisplayRating]         = useState(spot.rating);
+  const [displayReviewCount, setDisplayReviewCount] = useState(spot.reviewCount);
 
   /* ── Helpers ── */
-  function handleBusynessSubmit() {
+  async function handleBusynessSubmit() {
     if (selectedLevel === null) return;
-    const newPct = [5, 35, 65, 95][selectedLevel];   // map label → %
+    const newPct   = [5, 35, 65, 95][selectedLevel];
+    const newLabel = BUSYNESS_LEVELS[selectedLevel];
+
+    try {
+      await fetch(`/api/studyspots/${spot.id}/busyness`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ busyness: newPct, busynessLabel: newLabel }),
+      });
+    } catch (err) {
+      console.warn('Could not update busyness on server:', err);
+    }
+
     setBusyness(newPct);
-    // TODO: call API to update busyness
     setShowBusyness(false);
     setSelectedLevel(null);
   }
 
-  function handleRateSubmit() {
+  async function handleRateSubmit() {
     if (!selectedStar) return;
-    // TODO: call API to submit review
-    console.log('Review submitted', { stars: selectedStar, text: reviewText });
+
+    try {
+      await fetch(`/api/studyspots/${spot.id}/reviews`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rating: selectedStar, text: reviewText }),
+      });
+
+      // Refresh spot rating from backend
+      const updatedSpot = await fetch(`/api/studyspots/${spot.id}`).then(r => r.json());
+      if (updatedSpot.rating !== undefined) {
+        setDisplayRating(updatedSpot.rating);
+        setDisplayReviewCount(updatedSpot.reviewCount);
+      }
+    } catch (err) {
+      console.warn('Could not submit review:', err);
+    }
+
     setShowRate(false);
     setSelectedStar(0);
     setReviewText('');
   }
 
   function handleOpenMaps() {
-  const query = `${spot.name} ${spot.address}`;
-  const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
-  window.open(mapsUrl, '_blank', 'noopener,noreferrer');
-}
+    const query   = `${spot.name} ${spot.address}`;
+    const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+    window.open(mapsUrl, '_blank', 'noopener,noreferrer');
+  }
 
-function openAreaUpdate(area) {
-  setSelectedAreaName(area.name);
-  setSelectedAreaStatus(area.current);
-  setShowAreaUpdate(true);
-}
+  function openAreaUpdate(area) {
+    setSelectedAreaName(area.name);
+    setSelectedAreaStatus(area.current);
+    setShowAreaUpdate(true);
+  }
 
-function handleAreaUpdateSubmit() {
-  if (!selectedAreaStatus) return;
+  function handleAreaUpdateSubmit() {
+    if (!selectedAreaStatus) return;
+    setBobstAreas(prev =>
+      prev.map(area =>
+        area.name === selectedAreaName
+          ? { ...area, current: selectedAreaStatus }
+          : area
+      )
+    );
+    setShowAreaUpdate(false);
+    setSelectedAreaName('');
+    setSelectedAreaStatus(null);
+  }
 
-  setBobstAreas(prev =>
-    prev.map(area =>
-      area.name === selectedAreaName
-        ? { ...area, current: selectedAreaStatus }
-        : area
-    )
-  );
-
-  setShowAreaUpdate(false);
-  setSelectedAreaName('');
-  setSelectedAreaStatus(null);
-}
-
-  
   /* ── Render ── */
   return (
     <div className={styles.page}>
@@ -150,8 +171,8 @@ function handleAreaUpdateSubmit() {
                 setSaved(false);
               }
               // TODO: call API to save/unsave
-    }}
-  >
+            }}
+          >
             <BookmarkIcon filled={saved} />
             {saved ? 'Saved' : 'Save'}
           </button>
@@ -159,27 +180,26 @@ function handleAreaUpdateSubmit() {
 
         {/* Location + hours preview */}
         <div className={styles.metaRow}>
-  <span className={styles.metaItem}><PinIcon /> {spot.address}</span>
-  <span className={styles.metaItem}><ClockIcon /> {spot.hours[0].time}</span>
-</div>
+          <span className={styles.metaItem}><PinIcon /> {spot.address}</span>
+          <span className={styles.metaItem}><ClockIcon /> {spot.hours[0].time}</span>
+        </div>
 
-
-<div className={styles.directionsRow}>
-  <button className={styles.directionsBtn} onClick={handleOpenMaps}>
-    <PinIcon /> Get Directions
-  </button>
-</div>
+        <div className={styles.directionsRow}>
+          <button className={styles.directionsBtn} onClick={handleOpenMaps}>
+            <PinIcon /> Get Directions
+          </button>
+        </div>
 
         {/* Rating row */}
         <div className={styles.ratingRow}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
             <div className={styles.stars}>
               {[1,2,3,4,5].map(n => (
-                <StarIcon key={n} filled={n <= Math.round(spot.rating)} />
+                <StarIcon key={n} filled={n <= Math.round(displayRating)} />
               ))}
             </div>
             <span className={styles.ratingText}>
-              {spot.rating.toFixed(1)} · {spot.reviewCount} reviews
+              {displayRating.toFixed(1)} · {displayReviewCount} reviews
             </span>
           </div>
           <button className={styles.rateBtn} onClick={() => setShowRate(true)}>
@@ -206,78 +226,67 @@ function handleAreaUpdateSubmit() {
           </span>
         </div>
 
-      {isBobst && (
-  <div className={styles.microSection}>
-    <div className={styles.microHeaderRow}>
-      <div>
-        <p className={styles.sectionLabel}>Inside Bobst</p>
-        <h3 className={styles.microTitle}>Best areas based on how you want to study</h3>
-      </div>
-      <span className={styles.microBadge}>Pilot</span>
-    </div>
+        {isBobst && (
+          <div className={styles.microSection}>
+            <div className={styles.microHeaderRow}>
+              <div>
+                <p className={styles.sectionLabel}>Inside Bobst</p>
+                <h3 className={styles.microTitle}>Best areas based on how you want to study</h3>
+              </div>
+              <span className={styles.microBadge}>Pilot</span>
+            </div>
 
-    <div className={styles.microCards}>
-      {bobstAreas.map(area => (
-        <div key={area.name} className={styles.microCard}>
-          <div className={styles.microTopRow}>
-            <h4 className={styles.microCardTitle}>{area.name}</h4>
-
-            <div className={styles.microRightSide}>
-              <span className={styles.microStatus}>{area.current}</span>
-              <button
-                className={styles.microUpdateBtn}
-                onClick={() => openAreaUpdate(area)}
-              >
-                Update
-              </button>
+            <div className={styles.microCards}>
+              {bobstAreas.map(area => (
+                <div key={area.name} className={styles.microCard}>
+                  <div className={styles.microTopRow}>
+                    <h4 className={styles.microCardTitle}>{area.name}</h4>
+                    <div className={styles.microRightSide}>
+                      <span className={styles.microStatus}>{area.current}</span>
+                      <button
+                        className={styles.microUpdateBtn}
+                        onClick={() => openAreaUpdate(area)}
+                      >
+                        Update
+                      </button>
+                    </div>
+                  </div>
+                  <p className={styles.microDesc}>{area.description}</p>
+                  <div className={styles.microTags}>
+                    {area.tags.map(tag => (
+                      <span key={tag} className={styles.microTag}>{tag}</span>
+                    ))}
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
+        )}
 
-          <p className={styles.microDesc}>{area.description}</p>
-
-          <div className={styles.microTags}>
-            {area.tags.map(tag => (
-              <span key={tag} className={styles.microTag}>{tag}</span>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  </div>
-)}
-        
         {showAreaUpdate && (
-  <div className={styles.overlay} onClick={() => setShowAreaUpdate(false)}>
-    <div className={styles.overlayCard} onClick={e => e.stopPropagation()}>
-      <h2 className={styles.overlayTitle}>
-        How busy is {selectedAreaName} right now?
-      </h2>
-
-      <div className={styles.areaStatusGrid}>
-        {['Quiet', 'Moderate', 'Busy'].map(status => (
-          <button
-            key={status}
-            className={`${styles.levelBtn} ${
-              selectedAreaStatus === status ? styles.levelBtnActive : ''
-            }`}
-            onClick={() => setSelectedAreaStatus(status)}
-          >
-            {status}
-          </button>
-        ))}
-      </div>
-
-      <div className={styles.overlayActions}>
-        <Button variant="secondary" onClick={() => setShowAreaUpdate(false)}>
-          Cancel
-        </Button>
-        <Button disabled={!selectedAreaStatus} onClick={handleAreaUpdateSubmit}>
-          Submit
-        </Button>
-      </div>
-    </div>
-  </div>
-)}
+          <div className={styles.overlay} onClick={() => setShowAreaUpdate(false)}>
+            <div className={styles.overlayCard} onClick={e => e.stopPropagation()}>
+              <h2 className={styles.overlayTitle}>
+                How busy is {selectedAreaName} right now?
+              </h2>
+              <div className={styles.areaStatusGrid}>
+                {['Quiet', 'Moderate', 'Busy'].map(status => (
+                  <button
+                    key={status}
+                    className={`${styles.levelBtn} ${selectedAreaStatus === status ? styles.levelBtnActive : ''}`}
+                    onClick={() => setSelectedAreaStatus(status)}
+                  >
+                    {status}
+                  </button>
+                ))}
+              </div>
+              <div className={styles.overlayActions}>
+                <Button variant="secondary" onClick={() => setShowAreaUpdate(false)}>Cancel</Button>
+                <Button disabled={!selectedAreaStatus} onClick={handleAreaUpdateSubmit}>Submit</Button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Amenities */}
         <div style={{ marginBottom: 'var(--space-5)' }}>
@@ -300,27 +309,27 @@ function handleAreaUpdateSubmit() {
           <p className={styles.sectionLabel}>Hours</p>
           <div className={styles.hoursGrid}>
             {spot.hours.map(h => (
-  <div key={h.day} style={{ display: 'contents' }}>
-    <span className={styles.hoursDay}>{h.day}</span>
-    <span className={styles.hoursTime}>{h.time}</span>
-  </div>
-))}
+              <div key={h.day} style={{ display: 'contents' }}>
+                <span className={styles.hoursDay}>{h.day}</span>
+                <span className={styles.hoursTime}>{h.time}</span>
+              </div>
+            ))}
           </div>
         </div>
       </div>
 
       {/* ── Saved confirmation overlay ── */}
-{showSavedOverlay && (
-  <div className={styles.overlay} onClick={() => setShowSavedOverlay(false)}>
-    <div className={styles.overlayCard} onClick={e => e.stopPropagation()}>
-      <h2 className={styles.overlayTitle}>Saved!</h2>
-      <p className={styles.savedMessage}>Added to Saved Spots</p>
-      <div className={styles.overlayActions}>
-        <Button onClick={() => setShowSavedOverlay(false)}>Done</Button>
-      </div>
-    </div>
-  </div>
-)}
+      {showSavedOverlay && (
+        <div className={styles.overlay} onClick={() => setShowSavedOverlay(false)}>
+          <div className={styles.overlayCard} onClick={e => e.stopPropagation()}>
+            <h2 className={styles.overlayTitle}>Saved!</h2>
+            <p className={styles.savedMessage}>Added to Saved Spots</p>
+            <div className={styles.overlayActions}>
+              <Button onClick={() => setShowSavedOverlay(false)}>Done</Button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* ── Busyness overlay ── */}
       {showBusyness && (
@@ -351,8 +360,6 @@ function handleAreaUpdateSubmit() {
         <div className={styles.overlay} onClick={() => setShowRate(false)}>
           <div className={styles.overlayCard} onClick={e => e.stopPropagation()}>
             <h2 className={styles.overlayTitle}>Rate this spot</h2>
-
-            {/* Star picker */}
             <div className={styles.starPicker}>
               {[1,2,3,4,5].map(n => (
                 <span
@@ -364,7 +371,6 @@ function handleAreaUpdateSubmit() {
                 >★</span>
               ))}
             </div>
-
             <textarea
               className={styles.reviewTextarea}
               placeholder="Share what you liked or didn't like (optional)"
@@ -372,7 +378,6 @@ function handleAreaUpdateSubmit() {
               onChange={e => setReviewText(e.target.value)}
               maxLength={500}
             />
-
             <div className={styles.overlayActions}>
               <Button variant="secondary" onClick={() => setShowRate(false)}>Cancel</Button>
               <Button disabled={!selectedStar} onClick={handleRateSubmit}>Submit</Button>

--- a/front-end/src/pages/SpotListPage.js
+++ b/front-end/src/pages/SpotListPage.js
@@ -26,7 +26,7 @@ export default function SpotListPage() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch('http://localhost:5050/api/studyspots', { cache: 'no-store' })
+    fetch('/api/studyspots', { cache: 'no-store' })
       .then(res => {
         if (!res.ok) throw new Error(`Request failed: ${res.status}`);
         return res.json();


### PR DESCRIPTION
Adds two new backend endpoints to the spots router:
- PATCH /api/studyspots/:spotId/busyness — updates overall spot busyness
- POST /api/studyspots/:spotId/reviews — submits a star rating and optional review text

Wires up the busyness overlay and rate overlay on SpotDetailsPage to call these endpoints. Rating and review count update live after submission. Also fixes hardcoded localhost:5050 URL in SpotListPage to use the proxy instead.

Also expands auth tests to cover signup logic and authenticateUser.

59 unit tests passing.